### PR TITLE
Update ec2-macos-system-monitor and Amazon ENA Ethernet

### DIFF
--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -13,15 +13,27 @@
 # limitations under the License.
 
 cask "amazon-ena-ethernet" do
-  version "1.4.2"
-  sha256 "30c6a2d0082aca87d3f5b404a010ba8d37eea1f12a41d49f12e134b753fd591c"
+  version "1.5.0"
 
-  # amazon was verified as official when first introduced to the cask
-  url "https://aws-homebrew.s3-us-west-2.amazonaws.com/amazon-ena-ethernet-1.4.2-1.pkg"
+  if MacOS.version <= :mojave
+    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/amazon-ena-ethernet-1.5.0-1.mojave.pkg",
+        verified: "amazon"
+    sha256 "721ffeff3c82beaafbff237a5ec143e568000a35ebcb073d1c3381ec523881a3"
+    pkg "amazon-ena-ethernet-1.5.0-1.mojave.pkg"
+  elsif MacOS.version <= :catalina
+    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/amazon-ena-ethernet-1.5.0-1.catalina.pkg",
+        verified: "amazon"
+    sha256 "758d5c8cb1e8db6aa92931268ce8a57fe0ec23f965bc00708c487f4d0372c275"
+    pkg "amazon-ena-ethernet-1.5.0-1.catalina.pkg"
+  elsif MacOS.version <= :big_sur
+    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/amazon-ena-ethernet-1.5.0-1.bigsur.pkg",
+        verified: "amazon"
+    sha256 "d96a1d02a1194f4baf42622563b018247e554d2ecacafc4184e0041a0f715e87"
+    pkg "amazon-ena-ethernet-1.5.0-1.bigsur.pkg"
+  end
+
   name "Amazon ENA Ethernet"
   homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html"
-
-  pkg "amazon-ena-ethernet-1.4.2-1.pkg"
 
   uninstall pkgutil: "com.amazon.ec2.ena-ethernet"
 end

--- a/Formula/ec2-macos-system-monitor.rb
+++ b/Formula/ec2-macos-system-monitor.rb
@@ -14,42 +14,29 @@
 
 class Ec2MacosSystemMonitor < Formula
   desc "EC2 System Monitor for macOS"
-  homepage "https://docs.aws.amazon.com/AWSEC2/latest/macOSGuide/concepts.html"
-  url "https://aws-homebrew.s3-us-west-2.amazonaws.com/ec2-macos-system-monitor-1.1.0.tar.gz"
-  sha256 "65d7ef52f4f7ef7c853455db09c1b65349a84291002abfe722d046652210a5cd"
+  homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html"
+  url "https://aws-homebrew.s3-us-west-2.amazonaws.com/formula/ec2-macos-system-monitor/ec2-macos-system-monitor-1.2.0.tar.gz"
+  sha256 "277204db4a4dac507e5b73779723aa1df960f67083cd325f840b60616884ef92"
   license "Apache-2.0"
 
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    # Turn off module style for go 1.16 until we get module support enabled
-    system "go", "env", "-w", "GO111MODULE=off"
-    # Install dependencies
-    system "go", "get", "go.bug.st/serial"
-    system "go", "get", "github.com/shirou/gopsutil"
-    system "go", "get", "golang.org/x/sys/unix"
-    system "go", "get", "github.com/tklauser/go-sysconf"
     # Go build
-    system "go", "build", "-trimpath", "-ldflags", "-s -w", "cmd/relayd/relayd.go"
-    system "go", "build", "-trimpath", "-ldflags", "-s -w", "cmd/cpuutilization/cpuutilization.go"
+    system "go", "build", "-o", "cpuutilization", "-ldflags", "-s -w", "main.go"
     (libexec/"bin").mkpath
     libexec.install "cpuutilization" => "bin/send-cpu-utilization"
-    libexec.install "relayd" => "bin/ec2monitoring-relayd"
-    inreplace "bin/setup-ec2monitoring", "/usr/local/Cellar", libexec.to_s
-    bin.install "bin/setup-ec2monitoring"
-    inreplace "configuration/com.amazon.ec2.monitoring.agents.cpuutilization.plist",
+    inreplace "scripts/setup-ec2monitoring", "/usr/local/Cellar", libexec.to_s
+    bin.install "scripts/setup-ec2monitoring"
+    inreplace "init/com.amazon.ec2.monitoring.agents.cpuutilization.plist",
               "/usr/local/libexec",
-              "#{libexec}/bin"
-    inreplace "configuration/com.amazon.ec2.monitoring.relayd.plist", "/usr/local/libexec", "#{libexec}/bin"
-    libexec.install "configuration/com.amazon.ec2.monitoring.agents.cpuutilization.plist"
-    libexec.install "configuration/com.amazon.ec2.monitoring.relayd.plist"
+              "#{opt_prefix}/libexec/bin"
+    libexec.install "init/com.amazon.ec2.monitoring.agents.cpuutilization.plist"
   end
 
   def caveats
     <<~EOS
-      #{name} must be enabled/disabled with the tool setup-ec2monitoring.
+      #{name} must be enabled/disabled with the tool setup-ec2monitoring. If this was an update, another "enable" may be required.
 
         To enable/install #{name}:
 


### PR DESCRIPTION
This updates the Amazon EC2 System Monitor for macOS to 1.2.0 which is the first public GitHub release. It also updates Amazon ENA Ethernet to 1.5.0.