### PR TITLE
Update amazon-efs-utils Caveats for Apple Silicon

### DIFF
--- a/Formula/amazon-efs-utils.rb
+++ b/Formula/amazon-efs-utils.rb
@@ -204,18 +204,22 @@ class AmazonEfsUtils < Formula
 
   def caveats
     <<~EOS
-      Perform below actions to start using efs:
+      To start using Amazon EFS on EC2 x86 Mac instances (mac1.metal):
         sudo mkdir -p /Library/Filesystems/efs.fs/Contents/Resources
         sudo ln -s /usr/local/bin/mount.efs /Library/Filesystems/efs.fs/Contents/Resources/mount_efs
 
-      Perform below actions to stop using efs:
+      To start using Amazon EFS on EC2 M1 Mac instances (mac2.metal):
+        sudo mkdir -p /Library/Filesystems/efs.fs/Contents/Resources
+        sudo ln -s /opt/homebrew/bin/mount.efs /Library/Filesystems/efs.fs/Contents/Resources/mount_efs
+
+      To stop using Amazon EFS on EC2 Mac instances:
         sudo rm /Library/Filesystems/efs.fs/Contents/Resources/mount_efs
 
-      To enable watchdog for using TLS mounts:
+      To enable watchdog for TLS mounts:
         sudo cp #{libexec}/amazon-efs-mount-watchdog.plist /Library/LaunchAgents
         sudo launchctl load /Library/LaunchAgents/amazon-efs-mount-watchdog.plist
 
-      To disable watchdog for using TLS mounts:
+      To disable watchdog for TLS mounts:
           sudo launchctl unload /Library/LaunchAgents/amazon-efs-mount-watchdog.plist
     EOS
   end


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Homebrew changed their default install location for Apple Silicon to /opt/homebrew (see https://brew.sh/2021/02/05/homebrew-3.0.0/ for more details) This PR, along with https://github.com/aws/efs-utils/pull/137, contains changes to amazon-efs-utils to support EC2 M1 Mac instances. Thanks!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
