### PR TITLE
Update amazon-ena-ethernet to support Ventura

### DIFF
--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -30,7 +30,7 @@ cask "amazon-ena-ethernet" do
         verified: "amazon"
     sha256 "bbd9ab0382b306641598d101e7beec571c182d47ebd32efbae1f0e652aa0efa4"
     pkg "amazon-ena-ethernet-#{version}.bigsur.pkg"
-  elsif MacOS.version <= :monterey
+  elsif MacOS.version <= :ventura
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.monterey.pkg",
         verified: "amazon"
     sha256 "3cde67c25f339194753256ed911572bfa6a654b46b4af75d548dbcffc0b83634"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates the amazon-ena-ethernet cask to expand the conditional to support Ventura.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
