### PR TITLE
Update amazon-efs-utils.rb to support MacOS Ventura 

### DIFF
--- a/Formula/amazon-efs-utils.rb
+++ b/Formula/amazon-efs-utils.rb
@@ -15,10 +15,12 @@
 class AmazonEfsUtils < Formula
   include Language::Python::Virtualenv
 
+  version "1.34.5"
+  sha256 "317fa6d9ca35f84c00b0595462def018eb1375372334174ee8f00b107f98e0d1"
+  
+  url "https://aws-homebrew.s3.us-west-2.amazonaws.com/formula/amazon-efs-utils/v#{version}.tar.gz"
   desc "Utilities for Amazon Elastic File System (EFS)"
   homepage "https://aws.amazon.com/efs/"
-  url "https://aws-homebrew.s3.us-west-2.amazonaws.com/formula/amazon-efs-utils/v1.34.3.tar.gz"
-  sha256 "10255c7c8b174d2ccee8356e98174544de332401677fed8a05bb0df855205e45"
   license "MIT"
 
   depends_on "python@3"
@@ -179,6 +181,10 @@ class AmazonEfsUtils < Formula
     inreplace buildpath/"dist/efs-utils.conf", "/etc", libexec/"etc"
     inreplace buildpath/"dist/efs-utils.conf", "/var", libexec/"var"
     inreplace buildpath/"dist/amazon-efs-mount-watchdog.plist", "/var", libexec/"var"
+
+    if libexec.to_s.start_with?("/opt/homebrew")
+      inreplace buildpath/"dist/amazon-efs-mount-watchdog.plist", "/usr/local", "/opt/homebrew"
+    end
 
     (libexec/"etc/amazon/efs/").mkpath
     libexec.install buildpath/"dist/efs-utils.crt" => "etc/amazon/efs/efs-utils.crt"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update url and sha to support MacOS Ventura for all ec2 mac instance users
Add 'if check' to change the path in plist to enable watchdog in mac2.metal instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
