### PR TITLE
Update ec2-macos-init to 1.5.6

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.4"
-    sha256 "aec4c22971c66430221f5e44870cffe63512740c5d661c4542282ad048fc1ed2"
+    version "1.5.6"
+    sha256 "254e3bba87293b07f590c635538812928a3d0699c466813cb05dfc53ab10d1a7"
 
     build_version = "1"
     pkg_file = "ec2-macos-init-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Updating the ec2-macos-init Cask to use the latest version ([1.5.6](https://github.com/aws/ec2-macos-init/releases/tag/1.5.6)).

Diff between 1.5.4 and 1.5.6 - https://github.com/aws/ec2-macos-init/compare/1.5.4...1.5.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
