### PR TITLE
Update ec2-macos-init to 1.5.7

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.6"
-    sha256 "254e3bba87293b07f590c635538812928a3d0699c466813cb05dfc53ab10d1a7"
+    version "1.5.7"
+    sha256 "4e117f9e726a59578d2922565b1e7a04866f71d5160476ca55fed30745e34de4"
 
     build_version = "1"
     pkg_file = "ec2-macos-init-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update the ec2-macos-init Cask to version 1.5.7

https://github.com/aws/ec2-macos-init/releases/tag/1.5.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
