### PR TITLE
Add Cask for ec2-macos-utils 1.0.1

### DIFF
--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -1,0 +1,31 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cask "ec2-macos-utils" do
+    version "1.0.1"
+    sha256 "1983f1f2028060fc6249a9dc1baaa4586f0ff4e75dc5f425142f962c4d1eedc9"
+
+    build_version = "1"
+    pkg_file = "ec2-macos-utils-#{version}-#{build_version}_universal.pkg"
+
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-utils/#{pkg_file}",
+        verified: "amazon"
+    name "EC2 macOS Utils"
+    desc "Utilities for EC2 Mac instances"
+    homepage "https://github.com/aws/ec2-macos-utils"
+
+    pkg pkg_file
+
+    uninstall pkgutil: "com.amazon.ec2.macos-utils"
+end


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Create a new Cask for ec2-macos-utils starting at version 1.0.1

https://github.com/aws/ec2-macos-utils/releases/tag/1.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
