### PR TITLE
Update ec2-macos-init, ec2-macos-utils, and ec2-macos-system-monitor casks

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.7"
-    sha256 "4e117f9e726a59578d2922565b1e7a04866f71d5160476ca55fed30745e34de4"
+    version "1.5.9"
+    sha256 "c7a52b364f093783fed6d070eb024b20c4a30f2109be40f75c80212b8dd77a50"
 
     build_version = "1"
     pkg_file = "ec2-macos-init-#{version}-#{build_version}_universal.pkg"

--- a/Casks/ec2-macos-system-monitor.rb
+++ b/Casks/ec2-macos-system-monitor.rb
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 cask "ec2-macos-system-monitor" do
-    version "1.2.1"
-    sha256 "3cb8e77e6df22b964c64581d7d449770f017aa20737d1d0bd4a81430ced196e5"
+    version "1.3.0"
+    sha256 "6ac6170197065b1eac00ca5694a31375eb3b0da8557c8ee417b5846b50181b50"
 
-    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-system-monitor/ec2-macos-system-monitor-#{version}.pkg",
+    build_version = "1"
+    pkg_file = "ec2-macos-system-monitor-#{version}-#{build_version}_universal.pkg"
+
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-system-monitor/#{pkg_file}",
         verified: "amazon"
     name "EC2 System Monitor for macOS"
-    desc "Agent that runs on every mac1.metal instance to provide on-instance metrics in CloudWatch"
+    desc "Agent that runs on EC2 Mac instances to provide on-instance metrics in CloudWatch"
     homepage "https://github.com/aws/ec2-macos-system-monitor"
 
-    pkg "ec2-macos-system-monitor-#{version}.pkg"
+    pkg pkg_file
 
     uninstall_postflight do
         script = Tempfile.new('load_com.amazon.ec2.monitoring.agents.cpuutilization_')

--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-utils" do
-    version "1.0.1"
-    sha256 "1983f1f2028060fc6249a9dc1baaa4586f0ff4e75dc5f425142f962c4d1eedc9"
+    version "1.0.3"
+    sha256 "f01eb4aef002b7a419d9c6ef953d7a999f8a06a49164fdef3bb5a333b9aa8561"
 
     build_version = "1"
     pkg_file = "ec2-macos-utils-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Description of changes:*
- Update ec2-macos-init to 1.5.9
- Update ec2-macos-utils to 1.0.3
- Update ec2-macos-system-monitor to 1.3.0
- Update ec2-macos-system-monitor build instructions to account for multiple architectures 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
