### PR TITLE
Update the amazon-ena-ethernet-dext Cask to version 1.0.7

### DIFF
--- a/Casks/amazon-ena-ethernet-dext.rb
+++ b/Casks/amazon-ena-ethernet-dext.rb
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 cask "amazon-ena-ethernet-dext" do
-    version "1.0.6-p1"
+    version "1.0.7-p1"
     dextDriverKitVersion = "21.2"
   
     if Hardware::CPU.arm?
         if MacOS.version >= :monterey
             url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet-dext/amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg",
                 verified: "amazon"
-            sha256 "3e42d3f611675f5dd590401dc2006508b2738e32458e40e23c38065dc92aa227"
+            sha256 "464cb03d48ef97b032d7efe8af4662af256ef0a8cb292076782be674f00a16e7"
             pkg "amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg"
         else
             raise "The amazon-ena-ethernet-dext Cask does not support macOS #{MacOS.version}."

--- a/Casks/amazon-ena-ethernet-dext.rb
+++ b/Casks/amazon-ena-ethernet-dext.rb
@@ -15,7 +15,7 @@
 cask "amazon-ena-ethernet-dext" do
     version "1.0.7-p1"
     dextDriverKitVersion = "21.2"
-  
+
     if Hardware::CPU.arm?
         if MacOS.version >= :monterey
             url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet-dext/amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg",
@@ -28,9 +28,9 @@ cask "amazon-ena-ethernet-dext" do
     else
         raise "The amazon-ena-ethernet-dext Cask only supports the arm architecture."
     end
-  
+
     name "Amazon ENA Ethernet Dext"
     homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html"
-  
+
     uninstall pkgutil: "com.amazon.ec2.ena-ethernet.dext"
 end


### PR DESCRIPTION
*Issue #, if available:* resolves #37

*Description of changes:* This change updates the `amazon-ena-ethernet-dext` Cask to version 1.0.7 and removes some whitespace characters from the Cask file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
