### PR TITLE
Update ec2-macos-init to 1.5.10

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.9"
-    sha256 "c7a52b364f093783fed6d070eb024b20c4a30f2109be40f75c80212b8dd77a50"
+    version "1.5.10"
+    sha256 "51e9d98167cc37c36c869d96866746fed21654394e10e1659dcdabbb60721f43"
 
     build_version = "1"
     pkg_file = "ec2-macos-init-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change updates the `ec2-macos-init` Cask to version `1.5.10` - https://github.com/aws/ec2-macos-init/compare/1.5.9...1.5.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
