### PR TITLE
Update ec2-macos-utils to 1.0.4

### DIFF
--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-utils" do
-    version "1.0.3"
-    sha256 "f01eb4aef002b7a419d9c6ef953d7a999f8a06a49164fdef3bb5a333b9aa8561"
+    version "1.0.4"
+    sha256 "4ff036856fe5c11667d8005f3b94d6c0e17e50280194bf5aab89e36ec115136f"
 
     build_version = "1"
     pkg_file = "ec2-macos-utils-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change updates the `ec2-macos-utils` Cask to version `1.0.4` - https://github.com/aws/ec2-macos-utils/compare/1.0.3...1.0.4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
