### PR TITLE
Update ec2-macos-init to 1.5.10-2

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.10"
-    sha256 "51e9d98167cc37c36c869d96866746fed21654394e10e1659dcdabbb60721f43"
+    version "1.5.10-2"
+    sha256 "975a6f9228cc3b5b949598da65e1ad0b2d1fc4371ebf28cf68d3a3462c789a0c"
 
-    build_version = "1"
-    pkg_file = "ec2-macos-init-#{version}-#{build_version}_universal.pkg"
+    pkg_file = "ec2-macos-init-#{version}_universal.pkg"
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-init/#{pkg_file}",
         verified: "amazon"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change updates the `ec2-macos-init` Cask to a newer build of version 1.5.10.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
