### PR TITLE
fix: handle platforms and use actions to test

### DIFF
--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -61,7 +61,7 @@ jobs:
           key: syntax-style-cache-${{ github.sha }}
           restore-keys: syntax-style-cache-
       
-      - run: brew style ${{ github.repository }}
+      - run: brew style --except-cops Cask/Desc ${{ github.repository }}
         continue-on-error: true
 
       - run: brew typecheck ${{ github.repository }}

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -1,0 +1,99 @@
+# Largely cribbed from Homebrew's homebrew/core tap tests from:
+# https://github.com/Homebrew/homebrew-core/blob/201dbb92e491064e0aa8a0942e0ca9c3053158a2/.github/workflows/tests.yml#L34
+
+name: Homebrew Tap Tests
+
+on:
+  push:
+  pull_request:
+  merge_group:
+
+permissions:
+  # actions helpers do the checkout
+  contents: read
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  HOMEBREW_BOOTSNAP: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+  HOMEBREW_VERIFY_ATTESTATIONS: 1
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+concurrency:
+  group: "${{ github.ref }}"
+  # yield to latest change, cancel jobs in progress
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: false
+          test-bot: false
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-syntax-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-syntax-
+
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems --groups=style,typecheck
+
+      - name: Install shellcheck and shfmt
+        run: brew install shellcheck shfmt
+
+      - name: Cache style cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/Homebrew/style
+          key: syntax-style-cache-${{ github.sha }}
+          restore-keys: syntax-style-cache-
+      
+      - run: brew style ${{ github.repository }}
+        continue-on-error: true
+
+      - run: brew typecheck ${{ github.repository }}
+
+  audit:
+    name: audit
+    needs: syntax
+    strategy:
+      fail-fast: false
+      matrix:
+        macos: [macos-latest, macos-13]
+    runs-on: ${{ matrix.macos }}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: true
+          cask: true
+          test-bot: false
+
+      - name: Run brew readall on all casks (arm)
+        if: ${{ startsWith(runner.arch, 'ARM') }}
+        run: brew readall --os=all --arch=all ${{github.repository}}
+      - name: Run brew readall on all casks (intel)
+        if: ${{ startsWith(runner.arch, 'X') }}
+        run: brew readall --os=all ${{github.repository}}
+
+      - name: Run brew audit --skip-style on ${{github.repository}}
+        run: |
+          brew audit --os=all --arch=all --skip-style --except=version --tap ${{github.repository}}
+
+      - name: Run brew audit --online on ${{github.repository}}
+        run: |
+          brew audit --os=all --arch=all --skip-style --except=version --online --signing --tap ${{github.repository}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/test-cache/
+*.log
+\#*
+.#*
+.~*
+

--- a/Casks/amazon-ena-ethernet-dext.rb
+++ b/Casks/amazon-ena-ethernet-dext.rb
@@ -19,7 +19,7 @@ cask "amazon-ena-ethernet-dext" do
     depends_on macos: :monterey
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet-dext/amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg",
-        verified: "amazon"
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     sha256 "464cb03d48ef97b032d7efe8af4662af256ef0a8cb292076782be674f00a16e7"
     pkg "amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg"
 

--- a/Casks/amazon-ena-ethernet-dext.rb
+++ b/Casks/amazon-ena-ethernet-dext.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,17 +16,15 @@ cask "amazon-ena-ethernet-dext" do
     version "1.0.7-p1"
     dextDriverKitVersion = "21.2"
 
-    if Hardware::CPU.arm?
-        if MacOS.version >= :monterey
-            url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet-dext/amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg",
-                verified: "amazon"
-            sha256 "464cb03d48ef97b032d7efe8af4662af256ef0a8cb292076782be674f00a16e7"
-            pkg "amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg"
-        else
-            raise "The amazon-ena-ethernet-dext Cask does not support macOS #{MacOS.version}."
-        end
-    else
-        raise "The amazon-ena-ethernet-dext Cask only supports the arm architecture."
+    depends_on macos: :monterey
+
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet-dext/amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg",
+        verified: "amazon"
+    sha256 "464cb03d48ef97b032d7efe8af4662af256ef0a8cb292076782be674f00a16e7"
+    pkg "amazon-ena-ethernet-dext-app-#{version}-dk#{dextDriverKitVersion}-1.pkg"
+
+    on_intel do
+      disable! date: "2025-03-21", because: "unvalidated operating system major version"
     end
 
     name "Amazon ENA Ethernet Dext"

--- a/Casks/amazon-ena-ethernet-dext.rb
+++ b/Casks/amazon-ena-ethernet-dext.rb
@@ -27,6 +27,8 @@ cask "amazon-ena-ethernet-dext" do
       disable! date: "2025-03-21", because: "unvalidated operating system major version"
     end
 
+    livecheck { skip }
+
     name "Amazon ENA Ethernet Dext"
     homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html"
 

--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,24 +17,26 @@ cask "amazon-ena-ethernet" do
 
   if MacOS.version <= :mojave
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.mojave.pkg",
-        verified: "amazon"
+        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "17220a622a37c49dd874c8cd0ff44a5223dbdc6fd9dbb22861b84d90abb79f3b"
     pkg "amazon-ena-ethernet-#{version}.mojave.pkg"
   elsif MacOS.version <= :catalina
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.catalina.pkg",
-        verified: "amazon"
+        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "183dfd41b56883d84d3fa79a724fb6613d598c6d74c8d8a292eb885b0ffa5167"
     pkg "amazon-ena-ethernet-#{version}.catalina.pkg"
   elsif MacOS.version <= :big_sur
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.bigsur.pkg",
-        verified: "amazon"
+        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "bbd9ab0382b306641598d101e7beec571c182d47ebd32efbae1f0e652aa0efa4"
     pkg "amazon-ena-ethernet-#{version}.bigsur.pkg"
   elsif MacOS.version <= :ventura
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.monterey.pkg",
-        verified: "amazon"
+        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "3cde67c25f339194753256ed911572bfa6a654b46b4af75d548dbcffc0b83634"
     pkg "amazon-ena-ethernet-#{version}.monterey.pkg"
+  else
+    disable! date: "2025-03-21", because: "unvalidated operating system major version"
   end
 
   name "Amazon ENA Ethernet"

--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -16,23 +16,23 @@ cask "amazon-ena-ethernet" do
   version "1.5.2-2"
 
   if MacOS.version <= :mojave
-    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.mojave.pkg",
-        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.mojave.pkg",
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     sha256 "17220a622a37c49dd874c8cd0ff44a5223dbdc6fd9dbb22861b84d90abb79f3b"
     pkg "amazon-ena-ethernet-#{version}.mojave.pkg"
   elsif MacOS.version <= :catalina
-    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.catalina.pkg",
-        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.catalina.pkg",
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     sha256 "183dfd41b56883d84d3fa79a724fb6613d598c6d74c8d8a292eb885b0ffa5167"
     pkg "amazon-ena-ethernet-#{version}.catalina.pkg"
   elsif MacOS.version <= :big_sur
-    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.bigsur.pkg",
-        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.bigsur.pkg",
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     sha256 "bbd9ab0382b306641598d101e7beec571c182d47ebd32efbae1f0e652aa0efa4"
     pkg "amazon-ena-ethernet-#{version}.bigsur.pkg"
   elsif MacOS.version <= :sequoia
-    url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.monterey.pkg",
-        verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
+    url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.monterey.pkg",
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     sha256 "3cde67c25f339194753256ed911572bfa6a654b46b4af75d548dbcffc0b83634"
     pkg "amazon-ena-ethernet-#{version}.monterey.pkg"
   else

--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -39,6 +39,8 @@ cask "amazon-ena-ethernet" do
     disable! date: "2025-03-21", because: "unvalidated operating system major version"
   end
 
+  livecheck { skip }
+
   name "Amazon ENA Ethernet"
   homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html"
 

--- a/Casks/amazon-ena-ethernet.rb
+++ b/Casks/amazon-ena-ethernet.rb
@@ -30,7 +30,7 @@ cask "amazon-ena-ethernet" do
         verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "bbd9ab0382b306641598d101e7beec571c182d47ebd32efbae1f0e652aa0efa4"
     pkg "amazon-ena-ethernet-#{version}.bigsur.pkg"
-  elsif MacOS.version <= :ventura
+  elsif MacOS.version <= :sequoia
     url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/amazon-ena-ethernet-#{version}.monterey.pkg",
         verified: "aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ena-ethernet/"
     sha256 "3cde67c25f339194753256ed911572bfa6a654b46b4af75d548dbcffc0b83634"

--- a/Casks/amazon-ssm-agent.rb
+++ b/Casks/amazon-ssm-agent.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,8 @@ cask "amazon-ssm-agent" do
   end
   pkg_file = "amazon-ssm-agent-#{version}_#{arch}.pkg"
 
-  # amazon was verified as official when first introduced to the cask
-  url "https://aws-homebrew.s3-us-west-2.amazonaws.com/cask/amazon-ssm-agent/#{pkg_file}"
+  url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/amazon-ssm-agent/#{pkg_file}",
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
   name "Amazon SSM Agent"
   homepage "https://github.com/aws/amazon-ssm-agent"
 

--- a/Casks/amazon-ssm-agent.rb
+++ b/Casks/amazon-ssm-agent.rb
@@ -71,4 +71,6 @@ cask "amazon-ssm-agent" do
   pkg pkg_file
 
   uninstall pkgutil: "com.amazon.aws.ssm"
+
+  livecheck { skip }
 end

--- a/Casks/ec2-instance-connect.rb
+++ b/Casks/ec2-instance-connect.rb
@@ -52,4 +52,6 @@ cask "ec2-instance-connect" do
     pkg pkg_file
 
     uninstall pkgutil: "com.amazon.ec2-instance-connect.pkg"
+
+    livecheck { skip }
 end

--- a/Casks/ec2-instance-connect.rb
+++ b/Casks/ec2-instance-connect.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@ cask "ec2-instance-connect" do
     pkg_file = "ec2-instance-connect-#{version}_universal.pkg"
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-instance-connect/#{pkg_file}",
-        verified: "amazon"
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     name "EC2 Instance Connect"
     desc "Allows EC2 mac instances to access EC2 Instance Connect"
     homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html"

--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -37,4 +37,6 @@ cask "ec2-macos-init" do
                     sudo launchctl remove com.amazon.ec2.macos-init
         EOS
     end
+
+    livecheck { skip }
 end

--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@ cask "ec2-macos-init" do
     pkg_file = "ec2-macos-init-#{version}_universal.pkg"
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-init/#{pkg_file}",
-        verified: "amazon"
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     name "EC2 macOS Init"
     desc "Launch daemon used to initialize Mac instances within EC2"
     homepage "https://github.com/aws/ec2-macos-init"

--- a/Casks/ec2-macos-system-monitor.rb
+++ b/Casks/ec2-macos-system-monitor.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ cask "ec2-macos-system-monitor" do
     pkg_file = "ec2-macos-system-monitor-#{version}-#{build_version}_universal.pkg"
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-system-monitor/#{pkg_file}",
-        verified: "amazon"
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     name "EC2 System Monitor for macOS"
     desc "Agent that runs on EC2 Mac instances to provide on-instance metrics in CloudWatch"
     homepage "https://github.com/aws/ec2-macos-system-monitor"

--- a/Casks/ec2-macos-system-monitor.rb
+++ b/Casks/ec2-macos-system-monitor.rb
@@ -73,4 +73,6 @@ cask "ec2-macos-system-monitor" do
                     sudo setup-ec2monitoring disable
         EOS
     end
+
+    livecheck { skip }
 end

--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -28,4 +28,6 @@ cask "ec2-macos-utils" do
     pkg pkg_file
 
     uninstall pkgutil: "com.amazon.ec2.macos-utils"
+
+    livecheck { skip }
 end

--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -1,11 +1,11 @@
 #   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ cask "ec2-macos-utils" do
     pkg_file = "ec2-macos-utils-#{version}-#{build_version}_universal.pkg"
 
     url "https://aws-homebrew.s3.us-west-2.amazonaws.com/cask/ec2-macos-utils/#{pkg_file}",
-        verified: "amazon"
+        verified: "aws-homebrew.s3.us-west-2.amazonaws.com/cask/#{token}/"
     name "EC2 macOS Utils"
     desc "Utilities for EC2 Mac instances"
     homepage "https://github.com/aws/ec2-macos-utils"

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ export HOMEBREW_BUNDLE_USER_CACHE=$(abspath $(LOCAL_CACHE_DIR)/bundle-user-cache
 
 dev-setup: test-tap test-cache
 
-fmt format: check-style
-
 test-tap:
 	@-echo "(re)initialize tap worktree" >&2; sleep 1;
 	-$(git) worktree remove $(GIT_FORCE) $(HOMEBREW_PREFIX)/Library/Taps/$(TEST_HOMEBREW_TAP)
@@ -41,8 +39,11 @@ $(LOCAL_CACHE_DIR):
 
 check: check-style check-audit
 
+fmt format:
+	$(brew) style --except-cops Cask/Desc --fix .
+
 check-style:
-	$(brew) style .
+	$(brew) style --except-cops Cask/Desc .
 
 check-audit:
 	$(brew) audit --skip-style --except=version --signing --os=all --arch=all --display-filename --tap=$(TEST_HOMEBREW_TAP)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+git=git
+brew=brew
+
+TEST_HOMEBREW_TAP?=aws/homebrew-aws-next
+export HOMEBREW_PREFIX=$(shell $(brew) --prefix)
+
+export HOMEBREW_COLOR?=1
+export HOMEBREW_NO_COLOR?=
+export HOMEBREW_NO_EMOJI?=1
+export HOMEBREW_SIMULATE_MACOS_ON_LINUX?=1
+export HOMEBREW_VERBOSE?=
+export HOMEBREW_DEBUG?=
+
+export HOMEBREW_DEVELOPER=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_ENV_HINTS=1
+export HOMEBREW_BOOTSNAP=0
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_VERIFY_ATTESTATIONS=1
+export HOMEBREW_DISPLAY_INSTALL_TIMES=1
+
+LOCAL_CACHE_DIR=$(abspath ./test-cache)
+export HOMEBREW_CACHE=$(abspath $(LOCAL_CACHE_DIR)/homebrew-cache)
+export HOMEBREW_BUNDLE_USER_CACHE=$(abspath $(LOCAL_CACHE_DIR)/bundle-user-cache)
+
+.default: check-style
+
+dev-setup: test-tap test-cache
+
+fmt format: check-style
+
+test-tap:
+	@-echo "(re)initialize tap worktree" >&2; sleep 1;
+	-$(git) worktree remove $(GIT_FORCE) $(HOMEBREW_PREFIX)/Library/Taps/$(TEST_HOMEBREW_TAP)
+	$(git) worktree add $(HOMEBREW_PREFIX)/Library/Taps/$(TEST_HOMEBREW_TAP) HEAD
+
+test-cache: $(LOCAL_CACHE_DIR)
+
+$(LOCAL_CACHE_DIR):
+	mkdir $(LOCAL_CACHE_DIR) $(HOMEBREW_CACHE) $(HOMEBREW_BUNDLE_USER_CACHE)
+
+check: check-style check-audit
+
+check-style:
+	$(brew) style .
+
+check-audit:
+	$(brew) audit --skip-style --except=version --signing --os=all --arch=all --display-filename --tap=$(TEST_HOMEBREW_TAP)
+
+check-audit-slow: HOMEBREW_VERBOSE=1
+check-audit-slow:
+	$(brew) audit --skip-style --except=version --signing --os=all --arch=all --display-filename --online --tap=$(TEST_HOMEBREW_TAP)


### PR DESCRIPTION
*Issue #, if available:*

n/an

*Description of changes:*

This addresses some cases in which Homebrew now falls through on Cask urls.

GitHub Actions are added to defend against this in the future and to evaluate the entire Tap. This currently covers: (unenforced) style checks, auditing of critical Formula and Cask definitions, and performs an online check by fetching artifacts & doing codesigning checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
