### PR TITLE
Update ec2-macos-init, ec2-macos-system-monitor and ec2-macos-utils casks

### DIFF
--- a/Casks/ec2-macos-init.rb
+++ b/Casks/ec2-macos-init.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-init" do
-    version "1.5.10-2"
-    sha256 "975a6f9228cc3b5b949598da65e1ad0b2d1fc4371ebf28cf68d3a3462c789a0c"
+    version "1.5.11-2"
+    sha256 "f5470810f55cbcb0b1cf8521eeddca97f68342c0e354e59066ecee25979bac39"
 
     pkg_file = "ec2-macos-init-#{version}_universal.pkg"
 

--- a/Casks/ec2-macos-system-monitor.rb
+++ b/Casks/ec2-macos-system-monitor.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-system-monitor" do
-    version "1.3.0"
-    sha256 "6ac6170197065b1eac00ca5694a31375eb3b0da8557c8ee417b5846b50181b50"
+    version "1.3.1"
+    sha256 "0880a9cc4ecbd28320c1c1606e5db64c4a389dbdcad150717e698dfc4bbda541"
 
     build_version = "1"
     pkg_file = "ec2-macos-system-monitor-#{version}-#{build_version}_universal.pkg"

--- a/Casks/ec2-macos-utils.rb
+++ b/Casks/ec2-macos-utils.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cask "ec2-macos-utils" do
-    version "1.0.4"
-    sha256 "4ff036856fe5c11667d8005f3b94d6c0e17e50280194bf5aab89e36ec115136f"
+    version "1.0.5"
+    sha256 "877578edcf2dd1fb372665c76eeede8dfcbcac9812eea39e4c8b31072fa32dbc"
 
     build_version = "1"
     pkg_file = "ec2-macos-utils-#{version}-#{build_version}_universal.pkg"


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- Update ec2-macos-init to 1.5.11-2
- Update ec2-macos-system-monitor to 1.3.1
- Update ec2-macos-utils to 1.0.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
